### PR TITLE
Use correct casing in module names (PO and MO)

### DIFF
--- a/lib/expo/message.ex
+++ b/lib/expo/message.ex
@@ -125,7 +125,7 @@ defmodule Expo.Message do
 
   ## Examples
 
-      iex> %Expo.Messages{messages: [message]} = Expo.Po.parse_string!(\"""
+      iex> %Expo.Messages{messages: [message]} = Expo.PO.parse_string!(\"""
       ...> msgid "foo"
       ...> msgstr "bar"
       ...> \""")

--- a/lib/expo/message/plural.ex
+++ b/lib/expo/message/plural.ex
@@ -104,7 +104,7 @@ defmodule Expo.Message.Plural do
 
   ## Examples
 
-      iex> %Expo.Messages{messages: [message]} = Expo.Po.parse_string!(\"""
+      iex> %Expo.Messages{messages: [message]} = Expo.PO.parse_string!(\"""
       ...> msgid "foo"
       ...> msgid_plural "foos"
       ...> msgstr[0] "bar"

--- a/lib/expo/message/singular.ex
+++ b/lib/expo/message/singular.ex
@@ -94,7 +94,7 @@ defmodule Expo.Message.Singular do
 
   ## Examples
 
-      iex> %Expo.Messages{messages: [message]} = Expo.Po.parse_string!(\"""
+      iex> %Expo.Messages{messages: [message]} = Expo.PO.parse_string!(\"""
       ...> msgid "foo"
       ...> msgstr "bar"
       ...> \""")

--- a/lib/expo/mo.ex
+++ b/lib/expo/mo.ex
@@ -1,12 +1,12 @@
-defmodule Expo.Mo do
+defmodule Expo.MO do
   @moduledoc """
   `.mo` file handler
   """
 
   alias Expo.Messages
-  alias Expo.Mo.InvalidFileError
-  alias Expo.Mo.Parser
-  alias Expo.Mo.UnsupportedVersionError
+  alias Expo.MO.InvalidFileError
+  alias Expo.MO.Parser
+  alias Expo.MO.UnsupportedVersionError
 
   @type compose_options :: [
           {:endianness, :little | :big},
@@ -32,7 +32,7 @@ defmodule Expo.Mo do
       ...>     %Expo.Message.Singular{msgid: ["foo"], msgstr: ["bar"], comments: "A comment"}
       ...>   ]
       ...> }
-      ...> |> Expo.Mo.compose()
+      ...> |> Expo.MO.compose()
       ...> |> IO.iodata_to_binary()
       <<222, 18, 4, 149, 0, 0, 0, 0, 2, 0, 0, 0, 28, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0,
         60, 0, 0, 0, 0, 0, 0, 0, 60, 0, 0, 0, 3, 0, 0, 0, 61, 0, 0, 0, 25, 0, 0, 0,
@@ -42,14 +42,14 @@ defmodule Expo.Mo do
 
   """
   @spec compose(messages :: Messages.t(), opts :: compose_options()) :: iodata()
-  defdelegate compose(content, opts \\ []), to: Expo.Mo.Composer
+  defdelegate compose(content, opts \\ []), to: Expo.MO.Composer
 
   @doc """
   Parse `.mo` file
 
   ### Examples
 
-      iex> Expo.Mo.parse_binary(<<0xDE120495::size(4)-unit(8),
+      iex> Expo.MO.parse_binary(<<0xDE120495::size(4)-unit(8),
       ...>   0::little-unsigned-integer-size(2)-unit(8),
       ...>   0::little-unsigned-integer-size(2)-unit(8),
       ...>   0::little-unsigned-integer-size(4)-unit(8),
@@ -71,15 +71,15 @@ defmodule Expo.Mo do
   any errors.
 
   Works exactly like `parse_binary/1`, but returns a `Expo.Messages` struct
-  if there are no errors or raises a `Expo.Mo.InvalidFileError` error if there
+  if there are no errors or raises a `Expo.MO.InvalidFileError` error if there
   are.
 
   If the version of the `.mo` file is not supported, a
-  `Expo.Mo.UnsupportedVersionError` is raised.
+  `Expo.MO.UnsupportedVersionError` is raised.
 
   ## Examples
 
-      iex> Expo.Mo.parse_binary!(<<0xDE120495::size(4)-unit(8),
+      iex> Expo.MO.parse_binary!(<<0xDE120495::size(4)-unit(8),
       ...>   0::little-unsigned-integer-size(2)-unit(8),
       ...>   0::little-unsigned-integer-size(2)-unit(8),
       ...>   0::little-unsigned-integer-size(4)-unit(8),
@@ -89,8 +89,8 @@ defmodule Expo.Mo do
       ...>   0::little-unsigned-integer-size(4)-unit(8)>>)
       %Expo.Messages{headers: [], messages: []}
 
-      iex> Expo.Mo.parse_binary!("invalid")
-      ** (Expo.Mo.InvalidFileError) invalid file
+      iex> Expo.MO.parse_binary!("invalid")
+      ** (Expo.MO.InvalidFileError) invalid file
 
   """
   @spec parse_binary!(content :: binary(), options :: parse_options()) ::
@@ -136,11 +136,11 @@ defmodule Expo.Mo do
 
   ## Examples
 
-      {:ok, po} = Expo.Mo.parse_file "messages.po"
+      {:ok, po} = Expo.MO.parse_file "messages.po"
       po.file
       #=> "messages.po"
 
-      Expo.Mo.parse_file "nonexistent"
+      Expo.MO.parse_file "nonexistent"
       #=> {:error, :enoent}
 
   """
@@ -160,13 +160,13 @@ defmodule Expo.Mo do
   Parses the contents of a file into a `Expo.Messages` struct, raising if there
   are any errors.
 
-  Works like `parse_file/1`, except that it raises a `Expo.Mo.SyntaxError`
+  Works like `parse_file/1`, except that it raises a `Expo.MO.SyntaxError`
   exception if there's a syntax error in the file or a `File.Error` error if
   there's an error with reading the file.
 
   ## Examples
 
-      Expo.Mo.parse_file! "nonexistent.po"
+      Expo.MO.parse_file! "nonexistent.po"
       #=> ** (File.Error) could not parse "nonexistent.po": no such file or directory
 
   """

--- a/lib/expo/mo/composer.ex
+++ b/lib/expo/mo/composer.ex
@@ -1,12 +1,12 @@
-defmodule Expo.Mo.Composer do
+defmodule Expo.MO.Composer do
   @moduledoc false
 
   alias Expo.Message
   alias Expo.Messages
-  alias Expo.Mo
+  alias Expo.MO
   alias Expo.Util
 
-  @spec compose(messages :: Messages.t(), opts :: Mo.compose_options()) :: iodata()
+  @spec compose(messages :: Messages.t(), opts :: MO.compose_options()) :: iodata()
   def compose(messages, opts \\ []) do
     messages =
       Util.inject_meta_headers(
@@ -30,7 +30,7 @@ defmodule Expo.Mo.Composer do
       end
 
     if Keyword.get(opts, :statistics, false) do
-      send(self(), {Mo, :message_count, length(messages)})
+      send(self(), {MO, :message_count, length(messages)})
     end
 
     number_of_messages = length(messages)

--- a/lib/expo/mo/invalid_file_error.ex
+++ b/lib/expo/mo/invalid_file_error.ex
@@ -1,6 +1,6 @@
-defmodule Expo.Mo.InvalidFileError do
+defmodule Expo.MO.InvalidFileError do
   @moduledoc """
-  An error raised when the content does not follow the Mo file structure.
+  An error raised when the content does not follow the MO file structure.
   """
 
   defexception [:message]

--- a/lib/expo/mo/parser.ex
+++ b/lib/expo/mo/parser.ex
@@ -1,15 +1,15 @@
-defmodule Expo.Mo.Parser do
+defmodule Expo.MO.Parser do
   @moduledoc false
 
   alias Expo.Message
   alias Expo.Messages
-  alias Expo.Mo
+  alias Expo.MO
   alias Expo.Util
 
-  @spec parse(content :: binary(), opts :: Mo.parse_options()) ::
+  @spec parse(content :: binary(), opts :: MO.parse_options()) ::
           {:ok, Messages.t()}
-          | Mo.invalid_file_error()
-          | Mo.unsupported_version_error()
+          | MO.invalid_file_error()
+          | MO.unsupported_version_error()
   def parse(content, opts)
 
   def parse(content, opts) when byte_size(content) >= 28 do

--- a/lib/expo/mo/unsupported_version_error.ex
+++ b/lib/expo/mo/unsupported_version_error.ex
@@ -1,4 +1,4 @@
-defmodule Expo.Mo.UnsupportedVersionError do
+defmodule Expo.MO.UnsupportedVersionError do
   @moduledoc """
   An error raised when the version of the mo file is not supported.
   """

--- a/lib/expo/po.ex
+++ b/lib/expo/po.ex
@@ -1,12 +1,12 @@
-defmodule Expo.Po do
+defmodule Expo.PO do
   @moduledoc """
   `.po` / `.pot` file handler
   """
 
   alias Expo.Messages
-  alias Expo.Po.DuplicateMessagesError
-  alias Expo.Po.Parser
-  alias Expo.Po.SyntaxError
+  alias Expo.PO.DuplicateMessagesError
+  alias Expo.PO.Parser
+  alias Expo.PO.SyntaxError
 
   @type parse_options :: [{:file, Path.t()}]
 
@@ -28,7 +28,7 @@ defmodule Expo.Po do
 
   After running the following code:
 
-      iodata = Expo.Po.compose %Expo.Messages{
+      iodata = Expo.PO.compose %Expo.Messages{
         headers: ["Last-Translator: Jane Doe"],
         messages: [
           %Expo.Message.Singular{msgid: ["foo"], msgstr: ["bar"], comments: "A comment"}
@@ -49,7 +49,7 @@ defmodule Expo.Po do
 
   """
   @spec compose(messages :: Messages.t()) :: iodata()
-  defdelegate compose(content), to: Expo.Po.Composer
+  defdelegate compose(content), to: Expo.PO.Composer
 
   @doc """
   Parses a string into a `Expo.Messages` struct.
@@ -60,7 +60,7 @@ defmodule Expo.Po do
 
   ## Examples
 
-      iex> {:ok, po} = Expo.Po.parse_string \"""
+      iex> {:ok, po} = Expo.PO.parse_string \"""
       ...> msgid "foo"
       ...> msgstr "bar"
       ...> \"""
@@ -72,7 +72,7 @@ defmodule Expo.Po do
       iex> po.headers
       []
 
-      iex> Expo.Po.parse_string "foo"
+      iex> Expo.PO.parse_string "foo"
       {:error, {:parse_error, "unknown keyword 'foo'", 1}}
 
   """
@@ -89,12 +89,12 @@ defmodule Expo.Po do
   any errors.
 
   Works exactly like `parse_string/1`, but returns a `Expo.Messages` struct
-  if there are no errors or raises a `Expo.Po.SyntaxError` error if there
+  if there are no errors or raises a `Expo.PO.SyntaxError` error if there
   are.
 
   ## Examples
 
-      iex> po = Expo.Po.parse_string! \"""
+      iex> po = Expo.PO.parse_string! \"""
       ...> msgid "foo"
       ...> msgstr "bar"
       ...> \"""
@@ -106,17 +106,17 @@ defmodule Expo.Po do
       iex> po.headers
       []
 
-      iex> Expo.Po.parse_string!("msgid")
-      ** (Expo.Po.SyntaxError) 1: no space after 'msgid'
+      iex> Expo.PO.parse_string!("msgid")
+      ** (Expo.PO.SyntaxError) 1: no space after 'msgid'
 
-      iex> Expo.Po.parse_string!(\"""
+      iex> Expo.PO.parse_string!(\"""
       ...> msgid "test"
       ...> msgstr ""
       ...>
       ...> msgid "test"
       ...> msgstr ""
       ...> \""")
-      ** (Expo.Po.DuplicateMessagesError) 4: found duplicate on line 4 for msgid: 'test'
+      ** (Expo.PO.DuplicateMessagesError) 4: found duplicate on line 4 for msgid: 'test'
 
   """
   @spec parse_string!(content :: String.t(), opts :: parse_options()) ::
@@ -164,11 +164,11 @@ defmodule Expo.Po do
 
   ## Examples
 
-      {:ok, po} = Expo.Po.parse_file "messages.po"
+      {:ok, po} = Expo.PO.parse_file "messages.po"
       po.file
       #=> "messages.po"
 
-      Expo.Po.parse_file "nonexistent"
+      Expo.PO.parse_file "nonexistent"
       #=> {:error, :enoent}
 
   """
@@ -187,13 +187,13 @@ defmodule Expo.Po do
   Parses the contents of a file into a `Expo.Messages` struct, raising if there
   are any errors.
 
-  Works like `parse_file/1`, except that it raises a `Expo.Po.SyntaxError`
+  Works like `parse_file/1`, except that it raises a `Expo.PO.SyntaxError`
   exception if there's a syntax error in the file or a `File.Error` error if
   there's an error with reading the file.
 
   ## Examples
 
-      Expo.Po.parse_file! "nonexistent.po"
+      Expo.PO.parse_file! "nonexistent.po"
       #=> ** (File.Error) could not parse "nonexistent.po": no such file or directory
 
   """

--- a/lib/expo/po/composer.ex
+++ b/lib/expo/po/composer.ex
@@ -1,4 +1,4 @@
-defmodule Expo.Po.Composer do
+defmodule Expo.PO.Composer do
   @moduledoc false
 
   alias Expo.Message

--- a/lib/expo/po/duplicate_translations_error.ex
+++ b/lib/expo/po/duplicate_translations_error.ex
@@ -1,4 +1,4 @@
-defmodule Expo.Po.DuplicateMessagesError do
+defmodule Expo.PO.DuplicateMessagesError do
   @moduledoc """
   An error raised when duplicate messages are detected.
   """

--- a/lib/expo/po/parser.ex
+++ b/lib/expo/po/parser.ex
@@ -1,18 +1,18 @@
-defmodule Expo.Po.Parser do
+defmodule Expo.PO.Parser do
   @moduledoc false
 
   alias Expo.Message
   alias Expo.Messages
-  alias Expo.Po
-  alias Expo.Po.Tokenizer
+  alias Expo.PO
+  alias Expo.PO.Tokenizer
   alias Expo.Util
 
   @bom <<0xEF, 0xBB, 0xBF>>
 
-  @spec parse(content :: binary(), opts :: Po.parse_options()) ::
+  @spec parse(content :: binary(), opts :: PO.parse_options()) ::
           {:ok, Messages.t()}
-          | Po.parse_error()
-          | Po.duplicate_messages_error()
+          | PO.parse_error()
+          | PO.duplicate_messages_error()
   def parse(content, opts) do
     content = prune_bom(content, Keyword.get(opts, :file, "nofile"))
 

--- a/lib/expo/po/syntax_error.ex
+++ b/lib/expo/po/syntax_error.ex
@@ -1,4 +1,4 @@
-defmodule Expo.Po.SyntaxError do
+defmodule Expo.PO.SyntaxError do
   @moduledoc """
   An error raised when the syntax in a PO file (a file ending in `.po`) isn't
   correct.

--- a/lib/expo/po/tokenizer.ex
+++ b/lib/expo/po/tokenizer.ex
@@ -1,4 +1,4 @@
-defmodule Expo.Po.Tokenizer do
+defmodule Expo.PO.Tokenizer do
   @moduledoc false
 
   # This module is responsible for turning a chunk of text (a string) into a

--- a/lib/mix/tasks/expo.msgmft.ex
+++ b/lib/mix/tasks/expo.msgmft.ex
@@ -18,8 +18,8 @@ defmodule Mix.Tasks.Expo.Msgfmt do
 
   use Mix.Task
 
-  alias Expo.Mo
-  alias Expo.Po
+  alias Expo.MO
+  alias Expo.PO
 
   @switches [
     use_fuzzy: :boolean,
@@ -55,9 +55,9 @@ defmodule Mix.Tasks.Expo.Msgfmt do
           file
       end
 
-    messages = Po.parse_file!(source_file)
+    messages = PO.parse_file!(source_file)
 
-    output = Mo.compose(messages, mo_compose_opts)
+    output = MO.compose(messages, mo_compose_opts)
 
     case output_file do
       nil -> IO.binwrite(:standard_io, IO.iodata_to_binary(output))
@@ -66,7 +66,7 @@ defmodule Mix.Tasks.Expo.Msgfmt do
 
     if Keyword.fetch!(mo_compose_opts, :statistics) do
       receive do
-        {Mo, :message_count, count} ->
+        {MO, :message_count, count} ->
           # Not using Mix.shell().info/1 since that will print into stdout and not stderr
           IO.puts(:standard_error, "#{count} translated messages.")
       end

--- a/test/expo/mo_test.exs
+++ b/test/expo/mo_test.exs
@@ -1,15 +1,15 @@
-defmodule Expo.MoTest do
+defmodule Expo.MOTest do
   @moduledoc false
 
   use ExUnit.Case, async: true
 
   alias Expo.Message
   alias Expo.Messages
-  alias Expo.Mo
-  alias Expo.Mo.InvalidFileError
-  alias Expo.Mo.UnsupportedVersionError
+  alias Expo.MO
+  alias Expo.MO.InvalidFileError
+  alias Expo.MO.UnsupportedVersionError
 
-  doctest Mo
+  doctest MO
 
   describe "compose/2" do
     for {endianness, start} <- [
@@ -42,10 +42,10 @@ defmodule Expo.MoTest do
         assert <<unquote(start), _rest::binary>> =
                  mo =
                  messages
-                 |> Mo.compose(endianness: unquote(endianness))
+                 |> MO.compose(endianness: unquote(endianness))
                  |> IO.iodata_to_binary()
 
-        assert {:ok, messages} == Mo.parse_binary(mo)
+        assert {:ok, messages} == MO.parse_binary(mo)
       end
 
       test "#{endianness} encodes unicode correctly" do
@@ -60,7 +60,7 @@ defmodule Expo.MoTest do
 
         encoded =
           messages
-          |> Mo.compose(endianness: unquote(endianness))
+          |> MO.compose(endianness: unquote(endianness))
           |> IO.iodata_to_binary()
 
         assert encoded == File.read!(file)
@@ -75,7 +75,7 @@ defmodule Expo.MoTest do
       }
 
       assert {:ok, %Messages{messages: []}} =
-               messages |> Mo.compose() |> IO.iodata_to_binary() |> Mo.parse_binary()
+               messages |> MO.compose() |> IO.iodata_to_binary() |> MO.parse_binary()
     end
 
     test "does not encode fuzzy messages except when requested" do
@@ -86,13 +86,13 @@ defmodule Expo.MoTest do
       }
 
       assert {:ok, %Messages{messages: []}} =
-               messages |> Mo.compose() |> IO.iodata_to_binary() |> Mo.parse_binary()
+               messages |> MO.compose() |> IO.iodata_to_binary() |> MO.parse_binary()
 
       assert {:ok, %Messages{messages: [_fuzzy]}} =
                messages
-               |> Mo.compose(use_fuzzy: true)
+               |> MO.compose(use_fuzzy: true)
                |> IO.iodata_to_binary()
-               |> Mo.parse_binary()
+               |> MO.parse_binary()
     end
 
     test "does send statistics when requested" do
@@ -102,13 +102,13 @@ defmodule Expo.MoTest do
         ]
       }
 
-      Mo.compose(messages, statistics: false)
+      MO.compose(messages, statistics: false)
 
-      refute_receive {Mo, :message_count, 1}
+      refute_receive {MO, :message_count, 1}
 
-      Mo.compose(messages, statistics: true)
+      MO.compose(messages, statistics: true)
 
-      assert_receive {Mo, :message_count, 1}
+      assert_receive {MO, :message_count, 1}
     end
   end
 
@@ -116,7 +116,7 @@ defmodule Expo.MoTest do
     for endianness <- [:big, :little] do
       test "#{endianness} parses headers" do
         file = Application.app_dir(:expo, "priv/test/mo/#{unquote(endianness)}/headers.mo")
-        assert {:ok, parsed} = Mo.parse_binary(File.read!(file))
+        assert {:ok, parsed} = MO.parse_binary(File.read!(file))
 
         assert %Messages{
                  headers: [
@@ -129,7 +129,7 @@ defmodule Expo.MoTest do
 
       test "#{endianness} parses singular message" do
         file = Application.app_dir(:expo, "priv/test/mo/#{unquote(endianness)}/singular.mo")
-        assert {:ok, parsed} = Mo.parse_binary(File.read!(file))
+        assert {:ok, parsed} = MO.parse_binary(File.read!(file))
 
         assert %Messages{
                  headers: [],
@@ -154,7 +154,7 @@ defmodule Expo.MoTest do
         file =
           Application.app_dir(:expo, "priv/test/mo/#{unquote(endianness)}/singular-msgctxt.mo")
 
-        assert {:ok, parsed} = Mo.parse_binary(File.read!(file))
+        assert {:ok, parsed} = MO.parse_binary(File.read!(file))
 
         assert %Messages{
                  headers: [],
@@ -177,7 +177,7 @@ defmodule Expo.MoTest do
 
       test "#{endianness} parses plural message" do
         file = Application.app_dir(:expo, "priv/test/mo/#{unquote(endianness)}/plural.mo")
-        assert {:ok, parsed} = Mo.parse_binary(File.read!(file))
+        assert {:ok, parsed} = MO.parse_binary(File.read!(file))
 
         assert %Messages{
                  headers: [],
@@ -201,7 +201,7 @@ defmodule Expo.MoTest do
 
       test "#{endianness} parses plural with msgctxt message" do
         file = Application.app_dir(:expo, "priv/test/mo/#{unquote(endianness)}/plural-msgctxt.mo")
-        assert {:ok, parsed} = Mo.parse_binary(File.read!(file))
+        assert {:ok, parsed} = MO.parse_binary(File.read!(file))
 
         assert %Messages{
                  headers: [],
@@ -225,7 +225,7 @@ defmodule Expo.MoTest do
 
       test "#{endianness} parses empty mo" do
         file = Application.app_dir(:expo, "priv/test/mo/#{unquote(endianness)}/empty.mo")
-        assert {:ok, parsed} = Mo.parse_binary(File.read!(file))
+        assert {:ok, parsed} = MO.parse_binary(File.read!(file))
 
         assert %Messages{
                  headers: [],
@@ -236,7 +236,7 @@ defmodule Expo.MoTest do
 
       test "#{endianness} parses mo with hash table" do
         file = Application.app_dir(:expo, "priv/test/mo/#{unquote(endianness)}/hash-table.mo")
-        assert {:ok, parsed} = Mo.parse_binary(File.read!(file))
+        assert {:ok, parsed} = MO.parse_binary(File.read!(file))
 
         assert %Messages{
                  messages: [%Message.Singular{msgid: ["foo"]}]
@@ -245,7 +245,7 @@ defmodule Expo.MoTest do
 
       test "#{endianness} parses unicode messages" do
         file = Application.app_dir(:expo, "priv/test/mo/#{unquote(endianness)}/unicode.mo")
-        assert {:ok, parsed} = Mo.parse_binary(File.read!(file))
+        assert {:ok, parsed} = MO.parse_binary(File.read!(file))
 
         assert %Messages{
                  headers: [
@@ -257,11 +257,11 @@ defmodule Expo.MoTest do
     end
 
     test "does not parse with invalid header" do
-      assert {:error, :invalid_file} = Mo.parse_binary(<<0>>)
-      assert {:error, :invalid_file} = Mo.parse_binary(<<0::unit(8)-size(32)>>)
+      assert {:error, :invalid_file} = MO.parse_binary(<<0>>)
+      assert {:error, :invalid_file} = MO.parse_binary(<<0::unit(8)-size(32)>>)
 
       assert {:error, {:unsupported_version, 1, 0}} =
-               Mo.parse_binary(
+               MO.parse_binary(
                  <<0xDE120495::size(4)-unit(8), 1::little-unsigned-integer-size(2)-unit(8),
                    0::little-unsigned-integer-size(2)-unit(8),
                    0::little-unsigned-integer-size(4)-unit(8),
@@ -276,7 +276,7 @@ defmodule Expo.MoTest do
   describe "parse_binary!/1" do
     test "works" do
       file = Application.app_dir(:expo, "priv/test/mo/little/headers.mo")
-      parsed = Mo.parse_binary!(File.read!(file))
+      parsed = MO.parse_binary!(File.read!(file))
 
       assert %Messages{
                headers: [
@@ -289,11 +289,11 @@ defmodule Expo.MoTest do
 
     test "raises for invalid file" do
       assert_raise InvalidFileError, "invalid file", fn ->
-        Mo.parse_binary!("invalid")
+        MO.parse_binary!("invalid")
       end
 
       assert_raise InvalidFileError, "file: invalid file", fn ->
-        Mo.parse_binary!("invalid", file: "file")
+        MO.parse_binary!("invalid", file: "file")
       end
     end
 
@@ -303,13 +303,13 @@ defmodule Expo.MoTest do
       assert_raise UnsupportedVersionError,
                    "invalid version, only ~> 0.0 is supported, 1.0 given",
                    fn ->
-                     Mo.parse_binary!(File.read!(file))
+                     MO.parse_binary!(File.read!(file))
                    end
 
       assert_raise UnsupportedVersionError,
                    "file: invalid version, only ~> 0.0 is supported, 1.0 given",
                    fn ->
-                     Mo.parse_binary!(File.read!(file), file: "file")
+                     MO.parse_binary!(File.read!(file), file: "file")
                    end
     end
   end
@@ -317,7 +317,7 @@ defmodule Expo.MoTest do
   describe "parse_file/1" do
     test "works" do
       file = Application.app_dir(:expo, "priv/test/mo/little/headers.mo")
-      assert {:ok, parsed} = Mo.parse_file(file)
+      assert {:ok, parsed} = MO.parse_file(file)
 
       assert %Messages{
                headers: [
@@ -331,24 +331,24 @@ defmodule Expo.MoTest do
     test "raises for invalid file" do
       file = Application.app_dir(:expo, "priv/test/po/bom.po")
 
-      assert {:error, :invalid_file} = Mo.parse_file(file)
+      assert {:error, :invalid_file} = MO.parse_file(file)
     end
 
     test "raises for unsupported version" do
       file = Application.app_dir(:expo, "priv/test/mo/unsupported_version.mo")
 
-      assert {:error, {:unsupported_version, 1, 0}} = Mo.parse_file(file)
+      assert {:error, {:unsupported_version, 1, 0}} = MO.parse_file(file)
     end
 
     test "missing file" do
-      assert Mo.parse_file("nonexistent") == {:error, :enoent}
+      assert MO.parse_file("nonexistent") == {:error, :enoent}
     end
   end
 
   describe "parse_file!/1" do
     test "works" do
       file = Application.app_dir(:expo, "priv/test/mo/little/headers.mo")
-      assert parsed = Mo.parse_file!(file)
+      assert parsed = MO.parse_file!(file)
 
       assert %Messages{
                headers: [
@@ -365,7 +365,7 @@ defmodule Expo.MoTest do
       assert_raise InvalidFileError,
                    "_build/test/lib/expo/priv/test/po/bom.po: invalid file",
                    fn ->
-                     Mo.parse_file!(file)
+                     MO.parse_file!(file)
                    end
     end
 
@@ -375,7 +375,7 @@ defmodule Expo.MoTest do
       assert_raise UnsupportedVersionError,
                    "_build/test/lib/expo/priv/test/mo/unsupported_version.mo: invalid version, only ~> 0.0 is supported, 1.0 given",
                    fn ->
-                     Mo.parse_file!(file)
+                     MO.parse_file!(file)
                    end
     end
 
@@ -386,7 +386,7 @@ defmodule Expo.MoTest do
       msg = ~r/could not parse "?nonexistent"?: no such file or directory/
 
       assert_raise File.Error, msg, fn ->
-        Mo.parse_file!("nonexistent")
+        MO.parse_file!("nonexistent")
       end
     end
   end

--- a/test/expo/po/tokenizer_test.exs
+++ b/test/expo/po/tokenizer_test.exs
@@ -1,7 +1,7 @@
-defmodule Expo.Po.TokenizerTest do
+defmodule Expo.PO.TokenizerTest do
   use ExUnit.Case, async: true
 
-  import Expo.Po.Tokenizer, only: [tokenize: 1]
+  import Expo.PO.Tokenizer, only: [tokenize: 1]
 
   test "keywords" do
     str = "msgid msgstr "

--- a/test/expo/po_test.exs
+++ b/test/expo/po_test.exs
@@ -1,4 +1,4 @@
-defmodule Expo.PoTest do
+defmodule Expo.POTest do
   @moduledoc false
 
   use ExUnit.Case, async: true
@@ -7,11 +7,11 @@ defmodule Expo.PoTest do
 
   alias Expo.Message
   alias Expo.Messages
-  alias Expo.Po
-  alias Expo.Po.DuplicateMessagesError
-  alias Expo.Po.SyntaxError
+  alias Expo.PO
+  alias Expo.PO.DuplicateMessagesError
+  alias Expo.PO.SyntaxError
 
-  doctest Po
+  doctest PO
 
   describe "compose/2" do
     test "single message" do
@@ -22,7 +22,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              msgid "foo"
              msgstr "bar"
              """
@@ -43,7 +43,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              msgid "one foo"
              msgid_plural "%{count} foos"
              msgstr[0] "one bar"
@@ -60,7 +60,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              msgid "foo"
              msgstr "bar"
 
@@ -81,7 +81,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              # comment
              # another comment
              msgid "foo"
@@ -101,7 +101,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              #. some comment
              #. another comment
              msgid "foo"
@@ -126,7 +126,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              #: foo.ex:1, lib/bar.ex:2
              #: file_without_line
              msgid "foo"
@@ -155,7 +155,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              #: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.ex:1
              #: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.ex:1
              #: cccccccccccccccccccccccccccccc.ex:1
@@ -176,7 +176,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              # other comment
              #, bar, baz, foo
              msgid "foo"
@@ -194,7 +194,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              msgid ""
              msgstr ""
              "Content-Type: text/plain\n"
@@ -221,7 +221,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              msgid ""
              "foo\n"
              "morefoo\n"
@@ -262,7 +262,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              msgid ""
              msgstr ""
              "Project-Id-Version: 1\n"
@@ -291,7 +291,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              msgid "\"quotes\""
              msgstr "foo \"bar\" baz"
 
@@ -303,7 +303,7 @@ defmodule Expo.PoTest do
     test "double quotes in headers are escaped" do
       messages = %Messages{headers: [~s(Foo: "bar"\n)], messages: []}
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              msgid ""
              msgstr "Foo: \"bar\"\n"
              """
@@ -318,7 +318,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              msgid "foo"
              msgstr "bar"
 
@@ -344,7 +344,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              msgctxt "baz"
              msgid "one foo"
              msgid_plural "%{count} foos"
@@ -365,7 +365,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              #| msgid "test"
              msgid "foo"
              msgstr "bar"
@@ -384,7 +384,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              #~ msgid "fo"
              #~ "o"
              #~ msgstr "bar"
@@ -413,7 +413,7 @@ defmodule Expo.PoTest do
         ]
       }
 
-      assert IO.iodata_to_binary(Po.compose(messages)) == ~S"""
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
              #| msgid "holla"
              msgid "hello"
              msgstr "ciao"
@@ -435,7 +435,7 @@ defmodule Expo.PoTest do
                   %Message.Singular{msgid: ["hel", "l", "o"], msgstr: ["ciao"]} = message
                 ]
               }} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "hel" "l"
                "o"
                msgstr "ciao"
@@ -465,7 +465,7 @@ defmodule Expo.PoTest do
                   }
                 ]
               }} =
-               Po.parse_string(~S"""
+               PO.parse_string(~S"""
                #: reference:7
                #, fuzzy
                #| msgid ""
@@ -497,7 +497,7 @@ defmodule Expo.PoTest do
                   }
                 ]
               }} =
-               Po.parse_string(~S"""
+               PO.parse_string(~S"""
                #: reference:8
                #| msgid "old"
                #| msgid_plural "olds"
@@ -526,7 +526,7 @@ defmodule Expo.PoTest do
                   }
                 ]
               }} =
-               Po.parse_string("""
+               PO.parse_string("""
                # comment
                #~ msgid "hel" "l"
                #~ "o"
@@ -549,7 +549,7 @@ defmodule Expo.PoTest do
                   %Message.Singular{msgid: ["hello", " world"], msgstr: ["ciao", " mondo"]}
                 ]
               }} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "hello" " world"
                msgstr "ciao" " mondo"
                """)
@@ -563,7 +563,7 @@ defmodule Expo.PoTest do
                   %Message.Singular{msgid: ["word"], msgstr: ["parola"]}
                 ]
               }} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "hello"
                msgstr "ciao"
                msgid "word"
@@ -576,7 +576,7 @@ defmodule Expo.PoTest do
               %Messages{
                 messages: [%Message.Singular{msgid: ["føø"], msgstr: ["bårπ"]}]
               }} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "føø"
                msgstr "bårπ"
                """)
@@ -592,7 +592,7 @@ defmodule Expo.PoTest do
                   } = message
                 ]
               }} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "foo"
                msgid_plural "foos"
                msgstr[0] "bar"
@@ -616,7 +616,7 @@ defmodule Expo.PoTest do
                   }
                 ]
               }} =
-               Po.parse_string("""
+               PO.parse_string("""
                # This is a message
                #: lib/foo.ex:32
                # Ah, another comment!
@@ -634,7 +634,7 @@ defmodule Expo.PoTest do
                   %Message.Singular{msgid: ["c"], msgstr: ["d"], comments: [" Comment"]}
                 ]
               }} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "a"
                msgstr "b"
                # Comment
@@ -645,18 +645,18 @@ defmodule Expo.PoTest do
 
     test "syntax error when there is no 'msgid'" do
       assert {:error, {:parse_error, "syntax error before: msgstr", 1}} =
-               Po.parse_string("msgstr \"foo\"")
+               PO.parse_string("msgstr \"foo\"")
 
       assert {:error, {:parse_error, "syntax error before: msgstr", 1}} =
-               Po.parse_string("msgstr \"foo\"")
+               PO.parse_string("msgstr \"foo\"")
 
       assert {:error, {:parse_error, "syntax error before: \"foo\"", 1}} =
-               Po.parse_string("\"foo\"")
+               PO.parse_string("\"foo\"")
     end
 
     test "if there's a msgid_plural, then plural forms must follow" do
       assert {:error, {:parse_error, "syntax error before: \"bar\"", 3}} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "foo"
                msgid_plural "foos"
                msgstr "bar"
@@ -665,19 +665,19 @@ defmodule Expo.PoTest do
 
     test "'msgid_plural' must come after 'msgid'" do
       assert {:error, {:parse_error, "syntax error before: msgid_plural", 1}} =
-               Po.parse_string("msgid_plural ")
+               PO.parse_string("msgid_plural ")
     end
 
     test "comments can't be placed between 'msgid' and 'msgstr'" do
       assert {:error, {:parse_error, "syntax error before: \"# Comment\"", 2}} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "foo"
                # Comment
                msgstr "bar"
                """)
 
       assert {:error, {:parse_error, "syntax error before: \"# Comment\"", 3}} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "foo"
                msgid_plural "foo"
                # Comment
@@ -687,7 +687,7 @@ defmodule Expo.PoTest do
 
     test "files with just comments are ok" do
       assert {:ok, %Messages{top_comments: ["# A comment", "# Another comment"]}} =
-               Po.parse_string("""
+               PO.parse_string("""
                # A comment
                # Another comment
                """)
@@ -695,7 +695,7 @@ defmodule Expo.PoTest do
 
     test "reference are extracted into the :reference field of a message" do
       assert {:ok, %Messages{messages: [%Message.Singular{} = message]}} =
-               Po.parse_string("""
+               PO.parse_string("""
                #: foo.ex:1
                #: f:2
                #: filename with spaces.ex:12
@@ -724,7 +724,7 @@ defmodule Expo.PoTest do
 
     test "extracted comments are extracted into the :extracted_comments field of a message" do
       assert {:ok, %Messages{messages: [%Message.Singular{} = message]}} =
-               Po.parse_string("""
+               PO.parse_string("""
                #. Extracted comment
                # Not an extracted comment
                #.Another extracted comment
@@ -745,7 +745,7 @@ defmodule Expo.PoTest do
 
     test "flags are extracted in to the :flags field of a message" do
       assert {:ok, %Messages{messages: [%Message.Singular{} = message]}} =
-               Po.parse_string("""
+               PO.parse_string("""
                #, flag,a-flag b-flag, c-flag
                # comment
                #, flag,  ,d-flag ,, e-flag
@@ -763,7 +763,7 @@ defmodule Expo.PoTest do
 
     test "headers are parsed when present" do
       assert {:ok, %Messages{messages: [], headers: headers}} =
-               Po.parse_string(~S"""
+               PO.parse_string(~S"""
                msgid ""
                msgstr "Language: en_US\n"
                       "Last-Translator: Jane Doe <jane@doe.com>\n"
@@ -779,7 +779,7 @@ defmodule Expo.PoTest do
                  {"found duplicate on line 4 for msgid: 'foo'", 4, 1},
                  {"found duplicate on line 7 for msgid: 'foo'", 7, 1}
                ]}} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "foo"
                msgstr "bar"
 
@@ -793,7 +793,7 @@ defmodule Expo.PoTest do
       # Works if the msgid is split differently as well
       assert {:error,
               {:duplicate_messages, [{"found duplicate on line 4 for msgid: 'foo'", 4, 1}]}} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "foo" ""
                msgstr "bar"
 
@@ -806,7 +806,7 @@ defmodule Expo.PoTest do
       assert {:error,
               {:duplicate_messages,
                [{"found duplicate on line 5 for msgid: 'foo' and msgid_plural: 'foos'", 5, 1}]}} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "foo"
                msgid_plural "foos"
                msgstr[0] "bar"
@@ -818,12 +818,12 @@ defmodule Expo.PoTest do
     end
 
     test "an empty list of tokens is parsed as an empty list of messages" do
-      assert {:ok, %Messages{messages: [], headers: []}} = Po.parse_string("")
+      assert {:ok, %Messages{messages: [], headers: []}} = PO.parse_string("")
     end
 
     test "multiple references on the same line are parsed correctly" do
       assert {:ok, %Messages{messages: [%Message.Singular{} = message]}} =
-               Po.parse_string("""
+               PO.parse_string("""
                #: foo.ex:1 bar.ex:2 with spaces.ex:3
                #: baz.ex:3 with:colon.ex:12
                msgid "foo"
@@ -838,7 +838,7 @@ defmodule Expo.PoTest do
 
     test "top-of-the-file comments are extracted correctly" do
       assert {:ok, %Messages{messages: [], top_comments: top_comments}} =
-               Po.parse_string("""
+               PO.parse_string("""
                # Top of the file
                ## Top of the file with two hashes
                msgid ""
@@ -850,7 +850,7 @@ defmodule Expo.PoTest do
 
     test "msgctxt is parsed correctly for messages" do
       assert {:ok, %Messages{messages: [%Message.Singular{} = message]}} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgctxt "my_" "context"
                msgid "my_msgid"
                msgstr "my_msgstr"
@@ -863,7 +863,7 @@ defmodule Expo.PoTest do
 
     test "msgctxt is parsed correctly for plural messages" do
       assert {:ok, %Messages{messages: [%Message.Plural{} = message]}} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgctxt "my_" "context"
                msgid "my_msgid"
                msgid_plural "my_msgid_plural"
@@ -878,7 +878,7 @@ defmodule Expo.PoTest do
 
     test "msgctxt is nil when no msgctxt is present in a message" do
       assert {:ok, %Messages{messages: [%Message.Singular{} = message]}} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "my_msgid"
                msgstr "my_msgstr"
                """)
@@ -889,7 +889,7 @@ defmodule Expo.PoTest do
     test "msgctxt causes a syntax error when misplaced" do
       # Badly placed msgctxt still causes a syntax error
       assert {:error, {:parse_error, "syntax error before: msgctxt", 2}} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgid "my_msgid"
                msgctxt "my_context"
                msgstr "my_msgstr"
@@ -904,7 +904,7 @@ defmodule Expo.PoTest do
                   %Message.Singular{} = message2
                 ]
               }} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgctxt "my_" "context"
                msgid "my_msgid"
                msgstr "my_msgstr"
@@ -929,7 +929,7 @@ defmodule Expo.PoTest do
                   %Message.Plural{} = message2
                 ]
               }} =
-               Po.parse_string("""
+               PO.parse_string("""
                msgctxt "my_" "context"
                msgid "my_msgid"
                msgid_plural "my_msgid_plural"
@@ -954,12 +954,12 @@ defmodule Expo.PoTest do
       fixture_path = Application.app_dir(:expo, "priv/test/po/valid.po")
 
       assert {:ok, %Messages{file: ^fixture_path}} =
-               Po.parse_string(File.read!(fixture_path), file: fixture_path)
+               PO.parse_string(File.read!(fixture_path), file: fixture_path)
     end
 
     test "tokens are printed as Elixir terms, not Erlang terms" do
       parsed =
-        Po.parse_string("""
+        PO.parse_string("""
         msgid ""
         # comment
         """)
@@ -974,7 +974,7 @@ defmodule Expo.PoTest do
       fixture_path = Application.app_dir(:expo, "priv/test/po/valid.po")
 
       assert %Messages{file: ^fixture_path} =
-               Po.parse_string!(File.read!(fixture_path), file: fixture_path)
+               PO.parse_string!(File.read!(fixture_path), file: fixture_path)
     end
 
     test "valid strings" do
@@ -986,14 +986,14 @@ defmodule Expo.PoTest do
       assert %Messages{
                messages: [%Message.Singular{msgid: ["foo"], msgstr: ["bar"]}],
                headers: []
-             } = Po.parse_string!(str)
+             } = PO.parse_string!(str)
     end
 
     test "invalid strings" do
       str = "msg"
 
       assert_raise SyntaxError, "1: unknown keyword 'msg'", fn ->
-        Po.parse_string!(str)
+        PO.parse_string!(str)
       end
 
       str = """
@@ -1003,11 +1003,11 @@ defmodule Expo.PoTest do
       """
 
       assert_raise SyntaxError, "2: syntax error before: msgstr", fn ->
-        Po.parse_string!(str)
+        PO.parse_string!(str)
       end
 
       assert_raise SyntaxError, "file:2: syntax error before: msgstr", fn ->
-        Po.parse_string!(str, file: "file")
+        PO.parse_string!(str, file: "file")
       end
     end
 
@@ -1017,7 +1017,7 @@ defmodule Expo.PoTest do
       msg = "file:4: found duplicate on line 4 for msgid: 'test'"
 
       assert_raise DuplicateMessagesError, msg, fn ->
-        Po.parse_string!(File.read!(fixture_path), file: "file")
+        PO.parse_string!(File.read!(fixture_path), file: "file")
       end
     end
   end
@@ -1042,13 +1042,13 @@ defmodule Expo.PoTest do
                 "Report-Msgid-Bugs-To: \n",
                 "POT-Creation-Date: 2010-07-06 12:31-0500\n"
               ]
-            }} = Po.parse_string(str)
+            }} = PO.parse_string(str)
   end
 
   describe "parse_file/1" do
     test "populates the :file field with the path of the parsed file" do
       fixture_path = Application.app_dir(:expo, "priv/test/po/valid.po")
-      assert {:ok, %Messages{file: ^fixture_path}} = Po.parse_file(fixture_path)
+      assert {:ok, %Messages{file: ^fixture_path}} = PO.parse_file(fixture_path)
     end
 
     test "valid file contents" do
@@ -1064,22 +1064,22 @@ defmodule Expo.PoTest do
                     msgstr: ["come stai,", " amico?"]
                   }
                 ]
-              }} = Po.parse_file(fixture_path)
+              }} = PO.parse_file(fixture_path)
     end
 
     test "invalid file contents" do
       fixture_path = Application.app_dir(:expo, "priv/test/po/invalid_syntax_error.po")
 
-      assert Po.parse_file(fixture_path) ==
+      assert PO.parse_file(fixture_path) ==
                {:error, {:parse_error, "syntax error before: msgstr", 4}}
 
       fixture_path = Application.app_dir(:expo, "priv/test/po/invalid_token_error.po")
 
-      assert Po.parse_file(fixture_path) == {:error, {:parse_error, "unknown keyword 'msg'", 3}}
+      assert PO.parse_file(fixture_path) == {:error, {:parse_error, "unknown keyword 'msg'", 3}}
     end
 
     test "missing file" do
-      assert Po.parse_file("nonexistent") == {:error, :enoent}
+      assert PO.parse_file("nonexistent") == {:error, :enoent}
     end
 
     test "file starting with a BOM byte sequence" do
@@ -1087,7 +1087,7 @@ defmodule Expo.PoTest do
 
       output =
         capture_io(:stderr, fn ->
-          assert {:ok, po} = Po.parse_file(fixture_path)
+          assert {:ok, po} = PO.parse_file(fixture_path)
           assert [%Message.Singular{msgid: ["foo"], msgstr: ["bar"]}] = po.messages
         end)
 
@@ -1099,7 +1099,7 @@ defmodule Expo.PoTest do
   describe "parse_file!/1" do
     test "populates the :file field with the path of the parsed file" do
       fixture_path = Application.app_dir(:expo, "priv/test/po/valid.po")
-      assert %Messages{file: ^fixture_path} = Po.parse_file!(fixture_path)
+      assert %Messages{file: ^fixture_path} = PO.parse_file!(fixture_path)
     end
 
     test "valid file contents" do
@@ -1114,7 +1114,7 @@ defmodule Expo.PoTest do
                    msgstr: ["come stai,", " amico?"]
                  }
                ]
-             } = Po.parse_file!(fixture_path)
+             } = PO.parse_file!(fixture_path)
     end
 
     test "invalid file contents" do
@@ -1124,14 +1124,14 @@ defmodule Expo.PoTest do
         "_build/test/lib/expo/priv/test/po/invalid_syntax_error.po:4: syntax error before: msgstr"
 
       assert_raise SyntaxError, msg, fn ->
-        Po.parse_file!(fixture_path)
+        PO.parse_file!(fixture_path)
       end
 
       fixture_path = Application.app_dir(:expo, "priv/test/po/invalid_token_error.po")
       msg = "_build/test/lib/expo/priv/test/po/invalid_token_error.po:3: unknown keyword 'msg'"
 
       assert_raise SyntaxError, msg, fn ->
-        Po.parse_file!(fixture_path)
+        PO.parse_file!(fixture_path)
       end
     end
 
@@ -1142,13 +1142,13 @@ defmodule Expo.PoTest do
       msg = ~r/could not parse "?nonexistent"?: no such file or directory/
 
       assert_raise File.Error, msg, fn ->
-        Po.parse_file!("nonexistent")
+        PO.parse_file!("nonexistent")
       end
     end
 
     test "empty files don't cause parsing errors" do
       fixture_path = Application.app_dir(:expo, "priv/test/po/empty.po")
-      assert %Messages{messages: [], headers: []} = Po.parse_file!(fixture_path)
+      assert %Messages{messages: [], headers: []} = PO.parse_file!(fixture_path)
     end
 
     test "file with duplicate messages" do
@@ -1158,7 +1158,7 @@ defmodule Expo.PoTest do
         "_build/test/lib/expo/priv/test/po/duplicate_messages.po:4: found duplicate on line 4 for msgid: 'test'"
 
       assert_raise DuplicateMessagesError, msg, fn ->
-        Po.parse_file!(fixture_path)
+        PO.parse_file!(fixture_path)
       end
     end
   end

--- a/test/mix/tasks/expo.msgfmt_test.exs
+++ b/test/mix/tasks/expo.msgfmt_test.exs
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Expo.MsgfmtTest do
   import ExUnit.CaptureIO
 
   alias Expo.Messages
-  alias Expo.Mo
+  alias Expo.MO
   alias Mix.Tasks.Expo.Msgfmt
 
   setup do
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Expo.MsgfmtTest do
         Msgfmt.run([po_path])
       end)
 
-    assert {:ok, _parsed} = Mo.parse_binary(out)
+    assert {:ok, _parsed} = MO.parse_binary(out)
   end
 
   test "exports mo to file", %{temp_file: temp_file} do
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Expo.MsgfmtTest do
 
     Msgfmt.run([po_path, "--output-file=#{temp_file}"])
 
-    assert {:ok, _parsed} = Mo.parse_file(temp_file)
+    assert {:ok, _parsed} = MO.parse_file(temp_file)
   end
 
   test "shows statistics", %{temp_file: temp_file} do
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Expo.MsgfmtTest do
 
     Msgfmt.run([po_path, "--output-file=#{temp_file}", "--use-fuzzy"])
 
-    assert {:ok, %Messages{messages: [_one, _two]}} = Mo.parse_file(temp_file)
+    assert {:ok, %Messages{messages: [_one, _two]}} = MO.parse_file(temp_file)
   end
 
   test "errors with missing file" do
@@ -73,10 +73,10 @@ defmodule Mix.Tasks.Expo.MsgfmtTest do
     po_path = Application.app_dir(:expo, "priv/test/po/valid.po")
 
     Msgfmt.run([po_path, "--output-file=#{temp_file}", "--endianness=little"])
-    assert {:ok, _parsed} = Mo.parse_file(temp_file)
+    assert {:ok, _parsed} = MO.parse_file(temp_file)
 
     Msgfmt.run([po_path, "--output-file=#{temp_file}", "--endianness=big"])
-    assert {:ok, _parsed} = Mo.parse_file(temp_file)
+    assert {:ok, _parsed} = MO.parse_file(temp_file)
 
     assert_raise Mix.Error,
                  "mix expo.msgfmt failed due to invalid endianness option\nExpected: \"little\" or \"big\"\nReceived: \"invalid\"\n",


### PR DESCRIPTION
In Elixir we use uppercase module names when we have acronyms in the module names, such as PO or MO. See `URI` for example.