### PR TITLE
Return exception structs from functions

### DIFF
--- a/lib/expo/mo/composer.ex
+++ b/lib/expo/mo/composer.ex
@@ -6,7 +6,7 @@ defmodule Expo.MO.Composer do
   alias Expo.MO
   alias Expo.Util
 
-  @spec compose(Messages.t(), MO.compose_options()) :: iodata()
+  @spec compose(Messages.t(), [MO.compose_option()]) :: iodata()
   def compose(messages, opts \\ []) do
     messages =
       Util.inject_meta_headers(

--- a/lib/expo/mo/invalid_file_error.ex
+++ b/lib/expo/mo/invalid_file_error.ex
@@ -1,22 +1,19 @@
 defmodule Expo.MO.InvalidFileError do
   @moduledoc """
   An error raised when the content does not follow the MO file structure.
+
+  The fields of this exception are public.
   """
 
-  defexception [:message]
+  @type t :: %__MODULE__{
+          file: Path.t()
+        }
 
-  @impl Exception
-  def exception(opts) do
-    reason = "invalid file"
+  defexception [:file]
 
-    msg =
-      if file = opts[:file] do
-        file = Path.relative_to_cwd(file)
-        "#{file}: #{reason}"
-      else
-        reason
-      end
-
-    %__MODULE__{message: msg}
+  @impl true
+  def message(%__MODULE__{file: file}) do
+    prefix = if file, do: "#{Path.relative_to_cwd(file)}: ", else: ""
+    "#{prefix}invalid file"
   end
 end

--- a/lib/expo/mo/invalid_file_error.ex
+++ b/lib/expo/mo/invalid_file_error.ex
@@ -6,7 +6,7 @@ defmodule Expo.MO.InvalidFileError do
   """
 
   @type t :: %__MODULE__{
-          file: Path.t()
+          file: Path.t() | nil
         }
 
   defexception [:file]

--- a/lib/expo/mo/invalid_file_error.ex
+++ b/lib/expo/mo/invalid_file_error.ex
@@ -11,7 +11,7 @@ defmodule Expo.MO.InvalidFileError do
 
   defexception [:file]
 
-  @impl true
+  @impl Exception
   def message(%__MODULE__{file: file}) do
     prefix = if file, do: "#{Path.relative_to_cwd(file)}: ", else: ""
     "#{prefix}invalid file"

--- a/lib/expo/mo/parser.ex
+++ b/lib/expo/mo/parser.ex
@@ -30,8 +30,6 @@ defmodule Expo.MO.Parser do
 
   def parse(_content, opts), do: {:error, %InvalidFileError{file: opts[:file]}}
 
-  defp parse_header(header_binary)
-
   defp parse_header(
          <<0xDE120495::size(4)-unit(8),
            file_format_revision_major::little-unsigned-integer-size(2)-unit(8),
@@ -97,8 +95,6 @@ defmodule Expo.MO.Parser do
       |> read_table_headers(binary_part(content, start_offset, number_of_elements * 2 * 4), [])
       |> Enum.map(&read_table_cell(content, &1))
 
-  defp read_table_headers(endianness, table_header, acc)
-
   defp read_table_headers(
          :big,
          <<cell_length::big-unsigned-integer-size(4)-unit(8),
@@ -117,7 +113,6 @@ defmodule Expo.MO.Parser do
 
   defp read_table_headers(_endianness, <<>>, acc), do: Enum.reverse(acc)
 
-  defp read_table_cell(content, position)
   defp read_table_cell(content, {offset, length}), do: binary_part(content, offset, length)
 
   defp to_message([msgid, msgstr]) do

--- a/lib/expo/mo/parser.ex
+++ b/lib/expo/mo/parser.ex
@@ -96,7 +96,7 @@ defmodule Expo.MO.Parser do
       |> Enum.map(&read_table_cell(content, &1))
 
   defp read_table_headers(
-         :big,
+         :big = _endianness,
          <<cell_length::big-unsigned-integer-size(4)-unit(8),
            cell_offset::big-unsigned-integer-size(4)-unit(8), rest::binary>>,
          acc
@@ -104,7 +104,7 @@ defmodule Expo.MO.Parser do
        do: read_table_headers(:big, rest, [{cell_offset, cell_length} | acc])
 
   defp read_table_headers(
-         :little,
+         :little = _endianness,
          <<cell_length::little-unsigned-integer-size(4)-unit(8),
            cell_offset::little-unsigned-integer-size(4)-unit(8), rest::binary>>,
          acc

--- a/lib/expo/mo/parser.ex
+++ b/lib/expo/mo/parser.ex
@@ -12,8 +12,8 @@ defmodule Expo.MO.Parser do
     with {:ok, {endianness, header}} <- parse_header(binary_part(content, 0, 28)),
          :ok <-
            check_version(header.file_format_revision_major, header.file_format_revision_minor),
-         messages <- parse_messages(endianness, header, content),
-         {headers, top_comments, messages} <- Util.extract_meta_headers(messages) do
+         messages = parse_messages(endianness, header, content),
+         {headers, top_comments, messages} = Util.extract_meta_headers(messages) do
       {:ok,
        %Messages{
          messages: messages,

--- a/lib/expo/mo/parser.ex
+++ b/lib/expo/mo/parser.ex
@@ -11,9 +11,10 @@ defmodule Expo.MO.Parser do
   def parse(content, opts) when byte_size(content) >= 28 do
     with {:ok, {endianness, header}} <- parse_header(binary_part(content, 0, 28)),
          :ok <-
-           check_version(header.file_format_revision_major, header.file_format_revision_minor),
-         messages = parse_messages(endianness, header, content),
-         {headers, top_comments, messages} = Util.extract_meta_headers(messages) do
+           check_version(header.file_format_revision_major, header.file_format_revision_minor) do
+      messages = parse_messages(endianness, header, content)
+      {headers, top_comments, messages} = Util.extract_meta_headers(messages)
+
       {:ok,
        %Messages{
          messages: messages,

--- a/lib/expo/mo/unsupported_version_error.ex
+++ b/lib/expo/mo/unsupported_version_error.ex
@@ -1,25 +1,15 @@
 defmodule Expo.MO.UnsupportedVersionError do
   @moduledoc """
-  An error raised when the version of the mo file is not supported.
+  An error returned when the version of the MO file is not supported.
+
+  All the fields in this struct are public.
   """
 
-  defexception [:message]
+  defexception [:major, :minor, :file]
 
-  @impl Exception
-  def exception(opts) do
-    major = Keyword.fetch!(opts, :major)
-    minor = Keyword.fetch!(opts, :minor)
-
-    reason = "invalid version, only ~> 0.0 is supported, #{major}.#{minor} given"
-
-    msg =
-      if file = opts[:file] do
-        file = Path.relative_to_cwd(file)
-        "#{file}: #{reason}"
-      else
-        reason
-      end
-
-    %__MODULE__{message: msg}
+  @impl true
+  def message(%__MODULE__{major: major, minor: minor, file: file}) do
+    prefix = if file, do: "#{Path.relative_to_cwd(file)}: ", else: ""
+    "#{prefix}invalid version, only ~> 0.0 is supported, #{major}.#{minor} given"
   end
 end

--- a/lib/expo/mo/unsupported_version_error.ex
+++ b/lib/expo/mo/unsupported_version_error.ex
@@ -8,7 +8,7 @@ defmodule Expo.MO.UnsupportedVersionError do
   @type t :: %__MODULE__{
           major: non_neg_integer,
           minor: non_neg_integer,
-          file: Path.t()
+          file: Path.t() | nil
         }
 
   defexception [:major, :minor, :file]

--- a/lib/expo/mo/unsupported_version_error.ex
+++ b/lib/expo/mo/unsupported_version_error.ex
@@ -5,6 +5,12 @@ defmodule Expo.MO.UnsupportedVersionError do
   All the fields in this struct are public.
   """
 
+  @type t :: %__MODULE__{
+          major: non_neg_integer,
+          minor: non_neg_integer,
+          file: Path.t()
+        }
+
   defexception [:major, :minor, :file]
 
   @impl Exception

--- a/lib/expo/mo/unsupported_version_error.ex
+++ b/lib/expo/mo/unsupported_version_error.ex
@@ -7,7 +7,7 @@ defmodule Expo.MO.UnsupportedVersionError do
 
   defexception [:major, :minor, :file]
 
-  @impl true
+  @impl Exception
   def message(%__MODULE__{major: major, minor: minor, file: file}) do
     prefix = if file, do: "#{Path.relative_to_cwd(file)}: ", else: ""
     "#{prefix}invalid version, only ~> 0.0 is supported, #{major}.#{minor} given"

--- a/lib/expo/po/duplicate_translations_error.ex
+++ b/lib/expo/po/duplicate_translations_error.ex
@@ -3,24 +3,19 @@ defmodule Expo.PO.DuplicateMessagesError do
   An error raised when duplicate messages are detected.
   """
 
-  defexception [:message]
+  @type t :: %__MODULE__{
+          file: Path.t(),
+          duplicates: [{message :: String.t(), line :: pos_integer, original_line: pos_integer}]
+        }
 
-  defp location(file, line)
-  defp location(nil, line), do: "#{line}"
-  defp location(file, line), do: "#{Path.relative_to_cwd(file)}:#{line}"
+  defexception [:file, :duplicates]
 
   @impl Exception
-  def exception(opts) do
-    file = Keyword.get(opts, :file)
+  def message(%__MODULE__{file: file, duplicates: duplicates}) do
+    prefix = if file, do: "#{Path.relative_to_cwd(file)}:", else: ""
 
-    message =
-      opts
-      |> Keyword.fetch!(:duplicates)
-      |> Enum.map(fn {message, new_line, _old_line} ->
-        "#{location(file, new_line)}: #{message}"
-      end)
-      |> Enum.join("\n")
-
-    %__MODULE__{message: message}
+    Enum.map_join(duplicates, "\n", fn {message, new_line, _old_line} ->
+      "#{prefix}#{new_line}: #{message}"
+    end)
   end
 end

--- a/lib/expo/po/duplicate_translations_error.ex
+++ b/lib/expo/po/duplicate_translations_error.ex
@@ -4,7 +4,7 @@ defmodule Expo.PO.DuplicateMessagesError do
   """
 
   @type t :: %__MODULE__{
-          file: Path.t(),
+          file: Path.t() | nil,
           duplicates: [{message :: String.t(), line :: pos_integer, original_line: pos_integer}]
         }
 

--- a/lib/expo/po/syntax_error.ex
+++ b/lib/expo/po/syntax_error.ex
@@ -4,21 +4,16 @@ defmodule Expo.PO.SyntaxError do
   correct.
   """
 
-  defexception [:message]
+  @type t :: %__MODULE__{
+          file: Path.t(),
+          line: pos_integer,
+          reason: String.t()
+        }
+
+  defexception [:file, :line, :reason]
 
   @impl Exception
-  def exception(opts) do
-    line = Keyword.fetch!(opts, :line)
-    reason = Keyword.fetch!(opts, :reason)
-
-    msg =
-      if file = opts[:file] do
-        file = Path.relative_to_cwd(file)
-        "#{file}:#{line}: #{reason}"
-      else
-        "#{line}: #{reason}"
-      end
-
-    %__MODULE__{message: msg}
+  def message(%__MODULE__{file: file, line: line, reason: reason}) do
+    if file, do: "#{Path.relative_to_cwd(file)}:#{line}: #{reason}", else: "#{line}: #{reason}"
   end
 end

--- a/lib/expo/po/syntax_error.ex
+++ b/lib/expo/po/syntax_error.ex
@@ -5,7 +5,7 @@ defmodule Expo.PO.SyntaxError do
   """
 
   @type t :: %__MODULE__{
-          file: Path.t(),
+          file: Path.t() | nil,
           line: pos_integer,
           reason: String.t()
         }

--- a/test/expo/mo_test.exs
+++ b/test/expo/mo_test.exs
@@ -1,11 +1,8 @@
 defmodule Expo.MOTest do
   use ExUnit.Case, async: true
 
-  alias Expo.Message
-  alias Expo.Messages
-  alias Expo.MO
-  alias Expo.MO.InvalidFileError
-  alias Expo.MO.UnsupportedVersionError
+  alias Expo.{Message, Messages, MO}
+  alias Expo.MO.{InvalidFileError, UnsupportedVersionError}
 
   doctest MO
 
@@ -254,10 +251,10 @@ defmodule Expo.MOTest do
     end
 
     test "does not parse with invalid header" do
-      assert {:error, :invalid_file} = MO.parse_binary(<<0>>)
-      assert {:error, :invalid_file} = MO.parse_binary(<<0::unit(8)-size(32)>>)
+      assert {:error, %InvalidFileError{file: nil}} = MO.parse_binary(<<0>>)
+      assert {:error, %InvalidFileError{file: nil}} = MO.parse_binary(<<0::unit(8)-size(32)>>)
 
-      assert {:error, {:unsupported_version, 1, 0}} =
+      assert {:error, %UnsupportedVersionError{major: 1, minor: 0}} =
                MO.parse_binary(
                  <<0xDE120495::size(4)-unit(8), 1::little-unsigned-integer-size(2)-unit(8),
                    0::little-unsigned-integer-size(2)-unit(8),
@@ -325,16 +322,16 @@ defmodule Expo.MOTest do
              } = parsed
     end
 
-    test "raises for invalid file" do
+    test "returns an error with an invalid file" do
       file = "test/fixtures/po/bom.po"
-
-      assert {:error, :invalid_file} = MO.parse_file(file)
+      assert {:error, %InvalidFileError{file: ^file}} = MO.parse_file(file)
     end
 
     test "raises for unsupported version" do
       file = "test/fixtures/mo/unsupported_version.mo"
 
-      assert {:error, {:unsupported_version, 1, 0}} = MO.parse_file(file)
+      assert {:error, %UnsupportedVersionError{major: 1, minor: 0, file: ^file}} =
+               MO.parse_file(file)
     end
 
     test "missing file" do


### PR DESCRIPTION
I'm a big fan of [this classic blog post](https://michal.muskala.eu/post/error-handling-in-elixir-libraries/). I try to always _return_ exceptions from libraries instead of returning any term and only converting it to an exception when raising. What are your thoughts on this? Especially interested in @josevalim's view, in general.

Btw, I didn't do this for PO errors too since I don't want to do too much in case there's disagreement on it :smile: