### PR TITLE
Misc doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ def deps do
 end
 ```
 
+## License
+
+Copyright 2022 JOSHMARTIN GmbH
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at:
+
+  > <http://www.apache.org/licenses/LICENSE-2.0>
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
 [docs]: https://hexdocs.pm/expo
 [elixir-gettext]: https://github.com/elixir-gettext/gettext
 [gettext]: https://www.gnu.org/software/gettext/

--- a/lib/expo/po/tokenizer.ex
+++ b/lib/expo/po/tokenizer.ex
@@ -149,7 +149,7 @@ defmodule Expo.PO.Tokenizer do
 
   # Unknown keyword.
   # At this point, there has to be a syntax error. Here, since the first byte is
-  # a letter (we don't take care of unicode ot fancy stuff, just ASCII letters),
+  # a letter (we don't take care of unicode or fancy stuff, just ASCII letters),
   # we assume there's an unknown keyword. We parse it with a regex
   # (`next_word/1`) so that the error message is informative.
   defp tokenize_line(<<letter, _rest::binary>> = binary, line, _line_prefix, _acc)

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Expo.MixProject do
     [
       source_url: @source_url,
       source_ref: "v" <> @version,
-      main: "README",
+      main: "readme",
       extras: ["README.md"]
     ]
   end

--- a/test/expo/messages_test.exs
+++ b/test/expo/messages_test.exs
@@ -62,12 +62,12 @@ defmodule Expo.MessagesTest do
              ]
     end
 
-    test "gets non existant header" do
+    test "gets non existent header" do
       assert Messages.get_header(%Messages{headers: [], messages: []}, "language") ==
                []
     end
 
-    test "gets multiple headers iwth same name" do
+    test "gets multiple headers with same name" do
       assert Messages.get_header(
                %Messages{
                  headers: [

--- a/test/mix/tasks/expo.msgfmt_test.exs
+++ b/test/mix/tasks/expo.msgfmt_test.exs
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.Expo.MsgfmtTest do
     po_path = "test/fixtures/po/valid.po"
 
     # Latin1 Encoding is needed so that the binary is untouched
-    # and does not acutally mean latin1.
+    # and does not actually mean latin1.
     out =
       capture_io([encoding: :latin1], fn ->
         Msgfmt.run([po_path])


### PR DESCRIPTION
List of changes:
- fix html index page not showing
- fix typos found via `codespell -S deps,doc -L symboll,fo,hel`
- add missing license term to readme