### PR TITLE
Adjust License Copyright to reflect code taken over from the original gettext library

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 JOSHMARTIN GmbH
+   Copyright 2015 Plataformatec Copyright 2020 Dashbit 2022 JOSHMARTIN GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ end
 
 ## License
 
-Copyright 2022 JOSHMARTIN GmbH
+Copyright 2015 Plataformatec Copyright 2020 Dashbit 2022 JOSHMARTIN GmbH
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
The following contributors worked on:

`git shortlog -n -s -- src/gettext_po_parser.yrl`:

```
    19  Andrea Leopardi
     1  Aleksei Magusev
```

`git shortlog -n -s -- lib/gettext/po*`

```
   124  Andrea Leopardi
     6  José Valim
     3  Aleksei Magusev
     3  Jonatan Männchen
     2  Christian von Roques
     2  Olafur Arason
     1  Alessandro Usseglio Viretta
     1  Enzo
     1  Eugene Pirogov
     1  Felix Maurer
     1  Wojciech Piekutowski
     1  kenny-evitt
```

Is that copyright accurate?