### PR TITLE
Support complete grammar for obsolete message parse

### DIFF
--- a/lib/expo/po/tokenizer.ex
+++ b/lib/expo/po/tokenizer.ex
@@ -82,8 +82,8 @@ defmodule Expo.PO.Tokenizer do
   end
 
   # Previous
-  defp tokenize_line(<<?#, ?|, rest::binary>>, line, "", acc) do
-    tokenize_line(rest, line, "#|", [{:previous, line} | acc])
+  defp tokenize_line(<<?#, ?|, rest::binary>>, line, line_prefix, acc) do
+    tokenize_line(rest, line, line_prefix <> "#|", [{:previous, line} | acc])
   end
 
   # Skip whitespace.
@@ -106,10 +106,10 @@ defmodule Expo.PO.Tokenizer do
   end
 
   # Comments.
-  defp tokenize_line(<<?#, _rest::binary>> = rest, line, "", acc) do
+  defp tokenize_line(<<?#, _rest::binary>> = rest, line, line_prefix, acc) do
     {contents, rest} = to_eol_or_eof(rest, "")
     acc = [{:comment, line, contents} | acc]
-    tokenize_line(rest, line, "", acc)
+    tokenize_line(rest, line, line_prefix, acc)
   end
 
   # `msgstr`.

--- a/src/expo_po_parser.yrl
+++ b/src/expo_po_parser.yrl
@@ -196,6 +196,11 @@ message_meta ->
     | '$2'
   ].
 message_meta ->
+  obsolete comment message_meta : [
+    {comments, extract_simple_token('$2')}
+    | '$3'
+  ].
+message_meta ->
   previous msgid str_lines previous msgid_plural str_lines message_meta : [
     {previous_messages, to_plural_message(
       [{msgid, extract_simple_token('$3')}, {msgid_plural, extract_simple_token('$6')}],
@@ -203,11 +208,25 @@ message_meta ->
     )} | '$7'
   ].
 message_meta ->
+  obsolete previous msgid str_lines obsolete previous msgid_plural str_lines message_meta : [
+    {previous_messages, to_plural_message(
+      [{msgid, extract_simple_token('$4')}, {msgid_plural, extract_simple_token('$8')}],
+      [{msgid, extract_line('$2')}, {msgid_plural, extract_line('$7')}]
+    )} | '$9'
+  ].
+message_meta ->
   previous msgid str_lines message_meta : [
     {previous_messages, to_singular_message(
       [{msgid, extract_simple_token('$3')}],
       [{msgid, extract_line('$2')}]
     )} | '$4'
+  ].
+message_meta ->
+  obsolete previous msgid str_lines message_meta : [
+    {previous_messages, to_singular_message(
+      [{msgid, extract_simple_token('$4')}],
+      [{msgid, extract_line('$3')}]
+    )} | '$5'
   ].
 
 Erlang code.

--- a/test/expo/po_test.exs
+++ b/test/expo/po_test.exs
@@ -519,7 +519,8 @@ defmodule Expo.POTest do
                     msgid: ["hell", "o"],
                     msgid_plural: ["hell", "os"],
                     msgstr: %{0 => ["holl", "a"]},
-                    comments: [" comment"],
+                    comments: [" comment", " comment"],
+                    previous_messages: [%Message.Singular{msgid: ["test"]}],
                     obsolete: true
                   }
                 ]
@@ -531,6 +532,8 @@ defmodule Expo.POTest do
                #~ msgstr "ciao"
 
                # comment
+               #~ # comment
+               #~ #| msgid "test"
                #~ msgid "hell"
                #~ "o"
                #~ msgid_plural "hell"


### PR DESCRIPTION
Fixes #91

@whatyouhide I run into some issues again with yecc:

```
Compiling 1 file (.yrl)
Parse action conflict scanning symbol obsolete in state 0:
   Reduce to message_meta from '$empty' (rule 25 at location 191:1)
      vs.
   shift to state 11, adding right sisters to '$empty'.
Conflict resolved in favor of shift.

Parse action conflict scanning symbol obsolete in state 8:
   Reduce to message_meta from '$empty' (rule 25 at location 191:1)
      vs.
   shift to state 11, adding right sisters to '$empty'.
Conflict resolved in favor of shift.

Parse action conflict scanning symbol obsolete in state 10:
   Reduce to message_meta from '$empty' (rule 25 at location 191:1)
      vs.
   shift to state 11, adding right sisters to '$empty'.
Conflict resolved in favor of shift.

Parse action conflict scanning symbol obsolete in state 14:
   Reduce to message_meta from '$empty' (rule 25 at location 191:1)
      vs.
   shift to state 11, adding right sisters to '$empty'.
Conflict resolved in favor of shift.

Parse action conflict scanning symbol obsolete in state 16:
   Reduce to message_meta from '$empty' (rule 25 at location 191:1)
      vs.
   shift to state 11, adding right sisters to '$empty'.
Conflict resolved in favor of shift.

Parse action conflict scanning symbol obsolete in state 19:
   Reduce to message_meta from '$empty' (rule 25 at location 191:1)
      vs.
   shift to state 11, adding right sisters to '$empty'.
Conflict resolved in favor of shift.

Parse action conflict scanning symbol obsolete in state 22:
   Reduce to message_meta from '$empty' (rule 25 at location 191:1)
      vs.
   shift to state 11, adding right sisters to '$empty'.
Conflict resolved in favor of shift.

Parse action conflict scanning symbol obsolete in state 25:
   Reduce to message_meta from '$empty' (rule 25 at location 191:1)
      vs.
   shift to state 27, adding right sisters to '$empty'.
Conflict resolved in favor of shift.

Parse action conflict scanning symbol obsolete in state 30:
   Reduce to message_meta from '$empty' (rule 25 at location 191:1)
      vs.
   shift to state 11, adding right sisters to '$empty'.
Conflict resolved in favor of shift.

Parse action conflict scanning symbol obsolete in state 48:
   Reduce to obsolete_pluralizations from obsolete pluralization (rule 22 at location 183:1)
      vs.
   shift to state 47, adding right sisters to pluralization.
Conflict resolved in favor of shift.

src/expo_po_parser.yrl: Warning: conflicts: 10 shift/reduce, 0 reduce/reduce
```

I have no clue how to solve these.