### PR TITLE
Reduce size of test matrix on CI

### DIFF
--- a/.github/workflows/part_test.yml
+++ b/.github/workflows/part_test.yml
@@ -57,12 +57,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - otp: '23.3'
+          - otp: '21.3'
             elixir: '1.11'
-          - otp: '24.3'
-            elixir: '1.12'
-          - otp: '24.3'
-            elixir: '1.13'
           - otp: '25.0'
             elixir: '1.14'
           - otp: '25.0'

--- a/.github/workflows/part_test.yml
+++ b/.github/workflows/part_test.yml
@@ -51,7 +51,7 @@ jobs:
   test:
     name: Run Tests & Submit Coverage
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
 
     strategy:
       fail-fast: false
@@ -59,12 +59,16 @@ jobs:
         include:
           - otp: '21.3'
             elixir: '1.11'
+            runs-on: ubuntu-18.04
           - otp: '25.0'
             elixir: '1.14'
+            runs-on: ubuntu-latest
           - otp: '25.0'
             elixir: 'main'
+            runs-on: ubuntu-latest
           - otp: '${{ inputs.otpVersion }}'
             elixir: '${{ inputs.elixirVersion }}'
+            runs-on: ubuntu-latest
             enable_coverage_export: 'true'
 
     env:


### PR DESCRIPTION
We try to test on latest published version and lowest supported combination of Elixir and OTP. Trying to avoid wasting compute resources 🙃 .

Closes #95.