### PR TITLE
Strict nonempty_list for msgid / msgstr

### DIFF
--- a/lib/expo/message.ex
+++ b/lib/expo/message.ex
@@ -15,8 +15,8 @@ defmodule Expo.Message do
 
   alias Expo.Message.{Plural, Singular}
 
-  @type msgid :: nonempty_list(String.t())
-  @type msgstr :: nonempty_list(String.t())
+  @type msgid :: [String.t(), ...]
+  @type msgstr :: [String.t(), ...]
   @type msgctxt :: String.t()
 
   @type t :: Singular.t() | Plural.t()

--- a/lib/expo/message.ex
+++ b/lib/expo/message.ex
@@ -15,8 +15,8 @@ defmodule Expo.Message do
 
   alias Expo.Message.{Plural, Singular}
 
-  @type msgid :: [String.t()]
-  @type msgstr :: [String.t()]
+  @type msgid :: nonempty_list(String.t())
+  @type msgstr :: nonempty_list(String.t())
   @type msgctxt :: String.t()
 
   @type t :: Singular.t() | Plural.t()

--- a/lib/expo/message/singular.ex
+++ b/lib/expo/message/singular.ex
@@ -55,7 +55,7 @@ defmodule Expo.Message.Singular do
   @derive {Inspect, except: [:__meta__]}
   defstruct [
     :msgid,
-    msgstr: [],
+    msgstr: [""],
     msgctxt: nil,
     comments: [],
     extracted_comments: [],

--- a/lib/expo/util.ex
+++ b/lib/expo/util.ex
@@ -17,6 +17,10 @@ defmodule Expo.Util do
   def inject_meta_headers(headers, comments, messages)
   def inject_meta_headers([], [], messages), do: messages
 
+  def inject_meta_headers([], comments, messages) do
+    inject_meta_headers([""], comments, messages)
+  end
+
   def inject_meta_headers(headers, comments, messages) do
     [
       %Message.Singular{msgid: [""], msgstr: headers, comments: comments}

--- a/test/expo/po_test.exs
+++ b/test/expo/po_test.exs
@@ -26,6 +26,34 @@ defmodule Expo.POTest do
              """
     end
 
+    test "empty message" do
+      messages = %Messages{
+        headers: [],
+        messages: [
+          %Message.Singular{msgid: [""]}
+        ]
+      }
+
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
+             msgid ""
+             msgstr ""
+             """
+    end
+
+    test "only comments" do
+      messages = %Messages{
+        headers: [],
+        messages: [],
+        top_comments: ["test"]
+      }
+
+      assert IO.iodata_to_binary(PO.compose(messages)) == ~S"""
+             #test
+             msgid ""
+             msgstr ""
+             """
+    end
+
     test "single plural message" do
       messages = %Messages{
         headers: [],


### PR DESCRIPTION
Fixes `FunctionClauseError` in https://github.com/elixir-gettext/gettext/issues/351#issuecomment-1429531773 / https://github.com/elixir-gettext/gettext/issues/355