### PR TITLE
temporarily force ssl_verify_fun to use rebar3 manager to fix CI

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -67,6 +67,10 @@ defmodule Expo.MixProject do
     [
       {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false},
       {:excoveralls, "~> 0.5", only: [:test], runtime: false},
+      # TODO: Remove when the following PR is merged & released:
+      # https://github.com/deadtrickster/ssl_verify_fun.erl/pull/27
+      {:ssl_verify_fun, "~> 1.1",
+       manager: :rebar3, only: [:test], runtime: false, override: true},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:credo, "~> 1.0", only: [:dev], runtime: false}
     ]


### PR DESCRIPTION
Reason: https://github.com/deadtrickster/ssl_verify_fun.erl/pull/27