### PR TITLE
Detect Duplicates for Singular and Plural Messages and provide merge command

### DIFF
--- a/lib/expo/po.ex
+++ b/lib/expo/po.ex
@@ -105,6 +105,7 @@ defmodule Expo.PO do
       ...> msgstr ""
       ...> \""")
       ** (Expo.PO.DuplicateMessagesError) 4: found duplicate on line 4 for msgid: 'test'
+      Run mix expo.msguniq with the input file to merge the duplicates
 
   """
   @spec parse_string!(String.t(), [parse_option()]) :: Messages.t()

--- a/lib/mix/tasks/expo.msguniq.ex
+++ b/lib/mix/tasks/expo.msguniq.ex
@@ -1,0 +1,102 @@
+defmodule Mix.Tasks.Expo.Msguniq do
+  @shortdoc "Unify duplicate translations in message catalog"
+
+  @moduledoc """
+  Unifies duplicate translations in the given PO file.
+
+  By default, this task outputs the file on standard output. If you want to
+  *overwrite* the given PO file, pass in the `--output` flag.
+
+  ## Usage
+
+      mix expo.msguniq PO_FILE [--output=OUTPUT_FILE]
+
+  ## Options
+
+  * `--output-file` (`-o`) - Default: `-` - File to store the output at. `-` for
+    STDOUT.
+
+  """
+  @moduledoc since: "0.5.0"
+
+  use Mix.Task
+
+  alias Expo.Message
+  alias Expo.Messages
+  alias Expo.PO
+  alias Expo.PO.DuplicateMessagesError
+
+  @switches [
+    output_file: :string
+  ]
+  @aliases [
+    o: :output_file
+  ]
+  @default_options [output_file: "-"]
+
+  @impl Mix.Task
+  def run(args) do
+    Application.ensure_all_started(:expo)
+    {opts, argv} = OptionParser.parse!(args, switches: @switches, aliases: @aliases)
+
+    opts = Keyword.merge(@default_options, opts)
+
+    output =
+      case opts[:output_file] do
+        "-" -> IO.stream(:stdio, :line)
+        file -> File.stream!(file)
+      end
+
+    file =
+      case argv do
+        [] ->
+          Mix.raise("""
+          mix expo.msguniq failed due to missing po file path argument
+          """)
+
+        [_file_one, _file_two | _other_files] ->
+          Mix.raise("""
+          mix expo.msguniq failed due to multiple po file path arguments
+          Only one is currently supported
+          """)
+
+        [file] ->
+          file
+      end
+
+    case PO.parse_file(file) do
+      {:ok, _messages} ->
+        :ok
+
+      {:error, %DuplicateMessagesError{duplicates: duplicates, catalogue: catalogue}} ->
+        po =
+          duplicates
+          |> Enum.reduce(catalogue, &merge_duplicate/2)
+          |> PO.compose()
+
+        _output = Enum.into(po, output)
+
+        IO.puts(:stderr, IO.ANSI.format("Merged #{length(duplicates)} translations"))
+
+      {:error, error} ->
+        raise error
+    end
+  end
+
+  defp merge_duplicate(
+         {duplicate, _error_message, _line, _original_line},
+         %Messages{messages: messages} = po
+       ) do
+    %Messages{
+      po
+      | messages:
+          Enum.map(messages, fn message ->
+            if Message.key(message) == Message.key(duplicate) do
+              Message.merge(message, duplicate)
+            else
+              message
+            end
+          end)
+    }
+  end
+end

--- a/test/expo/message_test.exs
+++ b/test/expo/message_test.exs
@@ -13,13 +13,13 @@ defmodule Expo.MessageTest do
     end
 
     test "plural" do
-      assert {"", {"foo", "foos"}} =
+      assert {"", "foo"} =
                Message.key(%Message.Plural{
                  msgid: ["foo"],
                  msgid_plural: ["foos"]
                })
 
-      assert {"ctxt", {"foo", "foos"}} =
+      assert {"ctxt", "foo"} =
                Message.key(%Message.Plural{
                  msgctxt: "ctxt",
                  msgid: ["foo"],

--- a/test/mix/tasks/expo.msguniq_test.exs
+++ b/test/mix/tasks/expo.msguniq_test.exs
@@ -1,0 +1,74 @@
+defmodule Mix.Tasks.Expo.MsguniqTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias Expo.Message
+  alias Expo.Messages
+  alias Expo.PO
+  alias Expo.PO.SyntaxError
+  alias Mix.Tasks.Expo.Msguniq
+
+  setup do
+    temp_file = Path.join(System.tmp_dir!(), make_ref() |> :erlang.phash2() |> to_string())
+
+    on_exit(fn -> File.rm(temp_file) end)
+
+    {:ok, temp_file: temp_file}
+  end
+
+  test "leaves file without duplicates as is", %{temp_file: temp_file} do
+    po_path = "test/fixtures/po/valid.po"
+
+    File.cp!(po_path, temp_file)
+
+    assert capture_io(fn ->
+             Msguniq.run([temp_file])
+           end) == ""
+  end
+
+  test "merges duplicates into output file", %{temp_file: temp_file} do
+    po_path = "test/fixtures/po/duplicate_messages.po"
+
+    assert capture_io(:stderr, fn ->
+             Msguniq.run([po_path, "--output-file", temp_file])
+           end) =~ "Merged 1 translation"
+
+    assert {:ok, %Messages{messages: [%Message.Singular{msgid: ["test"]}]}} =
+             PO.parse_file(temp_file)
+  end
+
+  test "merges duplicates into stdout" do
+    po_path = "test/fixtures/po/duplicate_messages.po"
+
+    output =
+      capture_io(fn ->
+        assert capture_io(:stderr, fn ->
+                 Msguniq.run([po_path])
+               end) =~ "Merged 1 translation"
+      end)
+
+    assert {:ok, %Messages{messages: [%Message.Singular{msgid: ["test"]}]}} =
+             PO.parse_string(output)
+  end
+
+  test "crashes with syntax error", %{temp_file: temp_file} do
+    File.write!(temp_file, "invalid")
+
+    assert_raise SyntaxError, fn ->
+      Msguniq.run([temp_file])
+    end
+  end
+
+  test "errors with missing file" do
+    assert_raise Mix.Error,
+                 "mix expo.msguniq failed due to missing po file path argument\n",
+                 fn -> Msguniq.run([]) end
+  end
+
+  test "errors with multiple files" do
+    assert_raise Mix.Error,
+                 "mix expo.msguniq failed due to multiple po file path arguments\nOnly one is currently supported\n",
+                 fn -> Msguniq.run(["file_one", "file_two"]) end
+  end
+end


### PR DESCRIPTION
Part of elixir-gettext/gettext#366

Hold off merging until a PR of `gettext` itself is merged that provides a migration path.