### PR TITLE
`Message.merge/2` unique flags / comments etc.

### DIFF
--- a/lib/expo/message.ex
+++ b/lib/expo/message.ex
@@ -118,7 +118,6 @@ defmodule Expo.Message do
       when mod in [Singular, Plural] and is_binary(flag),
       do: raw_has_flag?(flags, flag)
 
-  @spec raw_has_flag?([[String.t()]], String.t()) :: boolean()
   defp raw_has_flag?(flags, flag) when is_list(flags) when is_binary(flag),
     do: flag in List.flatten(flags)
 

--- a/test/expo/message_test.exs
+++ b/test/expo/message_test.exs
@@ -98,4 +98,31 @@ defmodule Expo.MessageTest do
       assert %Message.Plural{flags: [["one"]]} = Message.append_flag(plural, "one")
     end
   end
+
+  describe "merge/2" do
+    test "merges messages" do
+      msg1 = %Message.Singular{
+        msgid: ["test"],
+        flags: [["one"], ["two"]],
+        comments: ["one", "two"],
+        msgstr: ["une"]
+      }
+
+      msg2 = %Message.Plural{
+        msgid: ["test"],
+        msgid_plural: ["two"],
+        flags: [["two"]],
+        comments: ["two"],
+        msgstr: %{2 => ["deux"]}
+      }
+
+      assert %Message.Plural{
+               msgid: ["test"],
+               msgid_plural: ["two"],
+               flags: [["two", "one"]],
+               comments: ["two", "one"],
+               msgstr: %{0 => ["une"], 2 => ["deux"]}
+             } = Message.merge(msg1, msg2)
+    end
+  end
 end


### PR DESCRIPTION
Follow up from https://github.com/elixir-gettext/expo/pull/123#issuecomment-1814146277

I'm not using `MapSet` since there can be multiple lines of flags and we keep the structure as it is currently defined.

We already handle this in `Expo.Message.append_flag/2`, so I just reuse that functionality.