### PR TITLE
Upgrade @actions/artifact actions

### DIFF
--- a/.github/workflows/part_docs.yml
+++ b/.github/workflows/part_docs.yml
@@ -51,7 +51,7 @@ jobs:
       - run: mix deps.compile
       - run: mix compile --warning-as-errors
       - run: mix docs
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: docs
           path: doc
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: docs
           path: docs

--- a/.github/workflows/part_test.yml
+++ b/.github/workflows/part_test.yml
@@ -175,7 +175,7 @@ jobs:
           restore-keys: |
             dialyzer_plt_dev-${{ secrets.CACHE_VERSION }}-${{ runner.os }}test-${{ steps.setupBEAM.outputs.elixir-version }}-${{ steps.setupBEAM.outputs.otp-version }}-
       - run: mix dialyzer --plt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dialyzer_plt_dev
           path: priv/plts/
@@ -213,7 +213,7 @@ jobs:
             compile-${{ env.MIX_ENV }}-${{ secrets.CACHE_VERSION }}-${{ runner.os }}test-${{ steps.setupBEAM.outputs.elixir-version }}-${{ steps.setupBEAM.outputs.otp-version }}-
       - run: mix deps.compile
       - run: mix compile --warning-as-errors
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dialyzer_plt_dev
           path: priv/plts/


### PR DESCRIPTION
Need to be upgraded together. The upcoming dependabot PRs would fail on their own.