### PR TITLE
Fix `compose` output of extracted comments on plural messages

### DIFF
--- a/lib/expo/po/composer.ex
+++ b/lib/expo/po/composer.ex
@@ -42,7 +42,7 @@ defmodule Expo.PO.Composer do
 
     [
       dump_comments(t.comments, line_prefix),
-      dump_comments(t.extracted_comments, line_prefix),
+      dump_extracted_comments(t.extracted_comments, line_prefix),
       dump_references(t.references, line_prefix),
       dump_flags(t.flags, line_prefix),
       dump_previous_messages(t.previous_messages, line_prefix),

--- a/test/expo/parser_test.exs
+++ b/test/expo/parser_test.exs
@@ -390,6 +390,29 @@ defmodule Expo.ParserTest do
                msgstr[0] "bar"
                """)
     end
+
+    test "are associated with plural messages" do
+      assert [
+               %Message.Plural{
+                 msgid: ["foo"],
+                 msgid_plural: ["foos"],
+                 msgstr: %{0 => ["bar"], 1 => ["bars"]},
+                 comments: [" This is a message", " Ah, another comment!"],
+                 extracted_comments: [" An extracted comment"],
+                 references: [[{"lib/foo.ex", 32}]]
+               }
+             ] =
+               parse("""
+               # This is a message
+               #: lib/foo.ex:32
+               # Ah, another comment!
+               #. An extracted comment
+               msgid "foo"
+               msgid_plural "foos"
+               msgstr[0] "bar"
+               msgstr[1] "bars"
+               """)
+    end
   end
 
   defp parse(string) do


### PR DESCRIPTION
Fixes #132 

- Adds tests
  - Without the fix, two of the new tests fail
- One-line fix
  - With the fix, all tests pass:  `38 doctests, 349 tests, 0 failures`

I've also verified that this addresses the issues I am having with `gettext.extract` and `gettext.merge` when there are extracted comments on plural messages in .pot/.po files (as mentioned in #132).