### PR TITLE
Add option to strip metadata when parsing PO files

### DIFF
--- a/lib/expo/po.ex
+++ b/lib/expo/po.ex
@@ -6,7 +6,17 @@ defmodule Expo.PO do
   alias Expo.Messages
   alias Expo.PO.{DuplicateMessagesError, Parser, SyntaxError}
 
-  @type parse_option :: {:file, Path.t()}
+  @typedoc """
+  Parsing option.
+
+    * `:file` (`t:Path.t/0`) - path to use in error messages when using `parse_string/2`. If not present, errors
+      don't have a path.
+
+    * `:strip_meta` (`t:boolean/0`) - include only messages (no comments and other metadata) from the `.po` file
+    to reduce memory usage when meta information is not needed.
+    Defaults to `false`.
+  """
+  @type parse_option :: {:file, Path.t()} | {:strip_meta, boolean()}
 
   @doc """
   Dumps a `Expo.Messages` struct as iodata.

--- a/lib/expo/po/parser.ex
+++ b/lib/expo/po/parser.ex
@@ -12,7 +12,7 @@ defmodule Expo.PO.Parser do
   def parse(content, opts) do
     content = prune_bom(content, Keyword.get(opts, :file, "nofile"))
 
-    with {:ok, tokens} <- tokenize(content),
+    with {:ok, tokens} <- tokenize(content, opts),
          {:ok, po} <- parse_tokens(tokens),
          {:ok, po} <- check_for_duplicates(po) do
       {:ok, %Messages{po | file: Keyword.get(opts, :file)}}
@@ -22,8 +22,8 @@ defmodule Expo.PO.Parser do
     end
   end
 
-  defp tokenize(content) do
-    case Tokenizer.tokenize(content) do
+  defp tokenize(content, opts) do
+    case Tokenizer.tokenize(content, opts) do
       {:ok, tokens} -> {:ok, tokens}
       {:error, line, message} -> {:error, %SyntaxError{line: line, reason: message}}
     end

--- a/test/expo/parser_test.exs
+++ b/test/expo/parser_test.exs
@@ -454,8 +454,36 @@ defmodule Expo.ParserTest do
     end
   end
 
-  defp parse(string) do
-    case PO.parse_string(string) do
+  describe "strip meta" do
+    test "does not include extra information" do
+      assert [
+               %Message.Plural{
+                 msgid: ["foo"],
+                 msgid_plural: ["foos"],
+                 msgstr: %{0 => ["bar"], 1 => ["bars"]},
+                 comments: [],
+                 extracted_comments: [],
+                 references: []
+               }
+             ] =
+               parse(
+                 """
+                 # This is a message
+                 #: lib/foo.ex:32
+                 # Ah, another comment!
+                 #. An extracted comment
+                 msgid "foo"
+                 msgid_plural "foos"
+                 msgstr[0] "bar"
+                 msgstr[1] "bars"
+                 """,
+                 strip_meta: true
+               )
+    end
+  end
+
+  defp parse(string, options \\ []) do
+    case PO.parse_string(string, options) do
       {:ok, %Messages{messages: messages}} ->
         messages
 


### PR DESCRIPTION
Intended to be used in `Gettext.Backend` to speed up compiler and minimize memory usage when meta information is not needed.

Uses roughly a third of memory and is two times faster than including all meta information.

## Performance Test

```elixir
#!/usr/bin/env elixir

Mix.install([
  {:expo, path: "."},
  {:large_translations_catalogue,
   github: "jshmrtn/hygeia",
   branch: "main",
   app: false,
   compile: false,
   depth: 1,
   sparse: "priv/gettext"},
  {:benchee, "~> 1.3"}
])

require Logger

catalogue_base_path =
  Path.join([Mix.install_project_dir(), "deps", "large_translations_catalogue", "priv", "gettext"])

Logger.info("Preparing .mo files")

po_files = Path.wildcard(Path.join([catalogue_base_path, "*", "LC_MESSAGES", "*.po"]))

for path <- po_files do
  mo_path = Path.rootname(path, ".po") <> ".mo"
  Mix.Task.rerun("expo.msgfmt", [path, "--output-file", mo_path])
end

mo_files = Path.wildcard(Path.join([catalogue_base_path, "*", "LC_MESSAGES", "*.mo"]))

Logger.info("Performance Test Expo Parse")

Benchee.run(
  [
    expo_po_parse: fn ->
      for file <- po_files, do: Expo.PO.parse_file!(file)
    end,
    expo_po_strip_meta_parse: fn ->
      for file <- po_files, do: Expo.PO.parse_file!(file, strip_meta: true)
    end,
    expo_mo_parse: fn ->
      for file <- mo_files, do: Expo.MO.parse_file!(file)
    end
  ],
  warmup: 5,
  time: 10,
  memory_time: 2,
  parallel: System.schedulers_online()
)
```

Results:

```
13:48:54.184 [info] Preparing .mo files

13:48:54.236 [info] Performance Test Expo Parse
Operating System: Linux
CPU Information: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
Number of Available Cores: 8
Available memory: 46.76 GB
Elixir 1.17.2
Erlang 27.0.1
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 5 s
time: 10 s
memory time: 2 s
reduction time: 0 ns
parallel: 8
inputs: none specified
Estimated total run time: 51 s

Benchmarking expo_po_parse ...
Benchmarking expo_po_strip_meta_parse ...
Benchmarking expo_mo_parse ...
Calculating statistics...
Formatting results...

Name                               ips        average  deviation         median         99th %
expo_mo_parse                    56.77       17.62 ms    ±31.16%       16.07 ms       35.65 ms
expo_po_strip_meta_parse         14.12       70.81 ms    ±14.25%       69.67 ms      102.19 ms
expo_po_parse                     6.54      152.92 ms    ±11.27%      151.50 ms      199.97 ms

Comparison: 
expo_mo_parse                    56.77
expo_po_strip_meta_parse         14.12 - 4.02x slower +53.19 ms
expo_po_parse                     6.54 - 8.68x slower +135.31 ms

Memory usage statistics:

Name                             average  deviation         median         99th %
expo_mo_parse                    4.05 MB     ±0.00%        4.05 MB        4.05 MB
expo_po_strip_meta_parse        11.20 MB     ±0.00%       11.20 MB       11.20 MB
expo_po_parse                   33.67 MB     ±0.00%       33.67 MB       33.67 MB

Comparison: 
expo_mo_parse                    4.05 MB
expo_po_strip_meta_parse        11.20 MB - 2.77x memory usage +7.15 MB
expo_po_parse                   33.67 MB - 8.32x memory usage +29.62 MB
```